### PR TITLE
Fix bug with not detecting conflicts properly.

### DIFF
--- a/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
+++ b/plansys2_executor/src/plansys2_executor/bt_builder_plugins/simple_bt_builder.cpp
@@ -125,16 +125,37 @@ SimpleBTBuilder::get_node_contradict(
   }
 
   // Get the state prior to applying the effects
-  auto predicates = node->predicates;
-  auto functions = node->functions;
+  //auto predicates = node->predicates;
+  //auto functions = node->functions;
 
-  // Are all of the requirements satisfied?
-  if (is_action_executable(current->action, predicates, functions)) {
-    // Apply the effects
-    apply(current->action.action->at_start_effects, predicates, functions);
+  //const std::string i1 = "(" + parser::pddl::nameActionsToString(current->action.action) + ")";
+  //const std::string i2 = "(" + parser::pddl::nameActionsToString(node->action.action) + ")";
+  //printf("check1 contradict %s %s\n", i1.c_str(), i2.c_str());
+  //bool added = false;
+  //// Are all of the requirements satisfied?
+  //if (is_action_executable(current->action, predicates, functions)) {
+  //  // Apply the effects
+  //  apply(current->action.action->at_start_effects, predicates, functions);
 
-    // Look for a contradiction
-    if (!is_action_executable(node->action, predicates, functions)) {
+  //  printf("check2 contradict %s %s\n", i1.c_str(), i2.c_str());
+  //  // Look for a contradiction
+  //  if (!is_action_executable(node->action, predicates, functions)) {
+  //    contradictions.push_back(node);
+  //    added = true;
+  //  }
+  //}
+
+  // the previous algorithm assumes that the plan executes on time. it misses conflicts
+  // when a parallel action finishes early or late. This simple check
+  // will have many false positives for potential conflicts but that's probably good enough for our case
+  std::vector<plansys2::Predicate> p1 = node->predicates;
+  std::vector<plansys2::Function> f1 = node->functions;
+  // see if possible to execute both actions simultaneously
+  apply(current->action.action->at_start_requirements, p1, f1);
+  apply(current->action.action->over_all_requirements, p1, f1);
+  if (is_action_executable(node->action, p1, f1) && is_action_executable(current->action, p1, f1)) {
+    apply(current->action.action->at_start_effects, p1, f1);
+    if (!is_action_executable(node->action, p1, f1)) {
       contradictions.push_back(node);
     }
   }


### PR DESCRIPTION
The error we were getting 

`[ERROR] [1707782796.038097939, 238.392000000]: executor[(move honey jem_bay7 jem_bay6 jem_bay5):880006]Error checking at start reqs: (and (robot-available honey)(robot-at honey jem_bay7)(move-connected jem_bay7 jem_bay6)(location-real jem_bay6)(location-available jem_bay6)(locations-different jem_bay5 jem_bay7)(move-connected jem_bay5 jem_bay6)(location-available jem_bay5))`

seems to be due to a pretty fundamental bug in plansys2's executor. What was happening is it would try to run two honey actions in parallel, because it did not mark them as conflicting. This is because it only considered valid actions for conflicts in the current context. But, if the other robot finished late or early, this context changes, and at execution time the conflicted action becomes possible.

I changed the conflict detection behavior to be overly broad with many false positives rather than overly restrictive. I think it is probably not worth the effort to do better for us, but if anyone has better ideas go for it.

I have only tested this on the ISS plan (and not run it through the whole way due to other bugs). We may want to test this some more before merging.